### PR TITLE
fix: navigation overwrites route reference

### DIFF
--- a/src/router-service.ts
+++ b/src/router-service.ts
@@ -303,7 +303,11 @@ export class RouterService {
   public setCurrentRoute(route: Route): void {
     this.currentRoute = route;
     if (this.vm.config.globalProperties.$route) {
-      this.vm.config.globalProperties.$route = {...this.vm.config.globalProperties.$route, ...route};
+      this.vm.config.globalProperties.$route = Object.assign(
+        {},
+        this.vm.config.globalProperties.$route,
+        route
+      );
     } else {
       this.vm.config.globalProperties.$route = route;
     }

--- a/src/router-service.ts
+++ b/src/router-service.ts
@@ -303,10 +303,7 @@ export class RouterService {
   public setCurrentRoute(route: Route): void {
     this.currentRoute = route;
     if (this.vm.config.globalProperties.$route) {
-      this.vm.config.globalProperties.$route = Object.assign(
-        this.vm.config.globalProperties.$route,
-        route
-      );
+      this.vm.config.globalProperties.$route = {...this.vm.config.globalProperties.$route, ...route};
     } else {
       this.vm.config.globalProperties.$route = route;
     }


### PR DESCRIPTION
the navigation is overwriting the object that is in the routes array, and when trying to navigate to the route the router does not find the route because it no longer exists. The unreferenced route is now set and the routes array remains as defined by the developer
